### PR TITLE
qrb-ros-audio-service: support streaming playback

### DIFF
--- a/.github/workflows/build-check-sdk.yaml
+++ b/.github/workflows/build-check-sdk.yaml
@@ -49,8 +49,9 @@ jobs:
       - name: Download dependencies
         run: |
           cd ${WORKSPACE}
-          # no QRB ROS dependencies
-        
+          git clone https://github.com/quic-qrb-ros/qrb_ros_common.git
+          git clone https://github.com/quic-qrb-ros/qrb_ros_interfaces.git
+
       - name: build
         run: |
           cd ${SDK_DIR}

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,25 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-   * Redistributions of source code must retain the above copyright
-     notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-   * Redistributions in binary form must reproduce the above copyright
-     notice, this list of conditions and the following disclaimer in the
-     documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-   * Neither the name of the copyright holder nor the names of its
-     contributors may be used to endorse or promote products derived from
-     this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -6,86 +6,30 @@ The ROS package provides essential audio capabilities, it is the entry point for
 
 It supports both step-by-step and one-touch playback, allowing playback from built-in sounds. Additionally, it offers recording functionality, with the option to save to a local file or a topic.
 
-Playback and record capabilities depend on [qrb_ros_audio_common](https://github.qualcomm.com/QUIC-QRB-ROS/qrb_ros_audio_common).
+Playback and record capabilities depend on [qrb_ros_audio_common](https://github.com/QUIC-QRB-ROS/qrb_ros_audio_common).
 
-## Build
+## Documentation
 
-Use QIRP SDK to build.
+Please refer to the [QRB ROS Audio Service](https://quic-qrb-ros.github.io/main/packages/qrb_ros_audio_service/index.html) for more documents.
+- [Build](https://quic-qrb-ros.github.io/main/packages/qrb_ros_audio_service/index.html#Build)
+- [Run](https://quic-qrb-ros.github.io/main/packages/qrb_ros_audio_service/index.html#Run)
+- [Packages](https://quic-qrb-ros.github.io/main/packages/qrb_ros_audio_service/index.html#Packages)
 
-1. Build and install QIRP SDK follow [qirp-sdk-workflows](https://docs.qualcomm.com/bundle/publicresource/topics/80-65220-2/introduction_1.html?vproduct=1601111740013072&versionId=1befb000-28cc-4b51-8b35-81601178edee&facet=Qualcomm%20Intelligent%20Robotics%20(QIRP)%20Product%20SDK#qirp-sdk-workflows) or [Quick start (using the prebuild package)](https://docs.qualcomm.com/bundle/publicresource/topics/80-65220-2/quick-start_3.html?vproduct=1601111740013072&versionId=1befb000-28cc-4b51-8b35-81601178edee&facet=Qualcomm%20Intelligent%20Robotics%20(QIRP)%20Product%20SDK)
+## Contributing
 
-2. Setup environments follow [Set up the cross-compile environment](https://docs.qualcomm.com/bundle/publicresource/topics/80-65220-2/develop-your-first-application_6.html?product=1601111740013072&facet=Qualcomm%20Intelligent%20Robotics%20(QIRP)%20Product%20SDK&state=releasecandidate)
+We would love to have you as a part of the QRB ROS community. Whether you are helping us fix bugs, proposing new features, improving our documentation, or spreading the word, please refer to our [contribution guidelines](./CONTRIBUTING.md) and [code of conduct](./CODE_OF_CONDUCT.md).
 
-3. Create `ros_ws` directory in `<qirp_decompressed_workspace>/qirp-sdk/`
+- Bug report: If you see an error message or encounter failures, please create a [bug report](../../issues)
+- Feature Request: If you have an idea or if there is a capability that is missing and would make development easier and more robust, please submit a [feature request](../../issues)
 
-4. Put qrb_audio_manager, qrb_ros_audio_service, qrb_ros_audio_service_msgs and qrb_ros_audio_common_msgs packages under `<qirp_decompressed_workspace>/qirp-sdk/ros_ws`
+<Update link with template>
 
-     qrb_audio_manager and qrb_ros_audio_service in qrb_ros_audio_service:
-     ```bash
-     git clone https://github.qualcomm.com/QUIC-QRB-ROS/qrb_ros_audio_service.git
-     ```
-     qrb_ros_audio_service_msgs and qrb_ros_audio_common_msgs in qrb_ros_interfaces:
-     ```bash
-     git clone https://github.qualcomm.com/QUIC-QRB-ROS/qrb_ros_interfaces.git
-     ```
-6. Build this project
-     ```bash
-     export AMENT_PREFIX_PATH="${OECORE_TARGET_SYSROOT}/usr;${OECORE_NATIVE_SYSROOT}/usr"
-     export PYTHONPATH=${PYTHONPATH}:${OECORE_TARGET_SYSROOT}/usr/lib/python3.10/site-packages
+## Authors
 
-     colcon build --merge-install --cmake-args \
-       -Dpython3_ROOT_DIR=${OECORE_TARGET_SYSROOT}/usr \
-       -Dpython3_NumPy_INCLUDE_DIR=${OECORE_TARGET_SYSROOT}/usr/lib/python3.10/site-packages/numpy/core/include \
-       -DPYTHON_SOABI=cpython-310-aarch64-linux-gnu -DCMAKE_STAGING_PREFIX=$(pwd)/install \
-       -DCMAKE_PREFIX_PATH=$(pwd)/install/share \
-       -DBUILD_TESTING=OFF
-     ```
-7. Push to the device & Install
-     ```bash
-     cd <qirp_decompressed_workspace>/qirp-sdk/ros_ws/install
-     tar czvf qrb_ros_audio.tar.gz lib share
-     scp qrb_ros_audio.tar.gz root@[ip-addr]:/opt/
-     ssh root@[ip-addr]
-     tar -zxf /opt/qrb_ros_audio.tar.gz -C /opt/qcom/qirp-sdk/usr/
-     ```
+* **Yuchao Pan** - *Initial work* - [YuchPan](https://github.com/yuchpan)
 
-## Run
-
-1. Source this file to set up the environment on your device
-    ```bash
-    ssh root@[ip-addr]
-    export HOME=/opt
-    source /opt/qcom/qirp-sdk/qirp-setup.sh
-    export ROS_DOMAIN_ID=xx
-    source /usr/bin/ros_setup.bash
-    ```
-
-2. Use this launch file to run this package
-    ```bash
-    ros2 launch qrb_ros_audio_service audio_service.launch.py
-    ```
-
-3. Run qrb_ros_audio_common on another ssh terminal
-
-4. Run below test cases on third ssh terminal
-   
-     stream_handle indicate the stream created by Audio Service when command is "create". The value can be found on third ssh terminal:
-     if use "ROS Command":
-     `stream_handle=***`
-     if use "Python Script":
-     `command create success 1 stream_handle ***`
-   
-    | Test Case     | Using ROS Command   | Using Python Script      | 
-    | :--------- |:----------| ----------|
-    | Get build-in sound names | mkdir -p /opt/qcom/qirp-sdk/usr/share/qrb-audio-manager/sounds<br>chmod 0755 /opt/qcom/qirp-sdk/usr/share/qrb-audio-manager -R<br>adb push clip.wav /opt/qcom/qirp-sdk/usr/share/qrb-audio-manager/sounds<br>chmod 0644 /opt/qcom/qirp-sdk/usr/share/qrb-audio-manager/sounds/*<br><br>ros2 service call /audio_server qrb_ros_audio_service_msgs/srv/AudioRequest "{<br>command: "get-buildin-sound"<br>}"| python3 audio_service_test.py --get-buildin-sound |
-    | One-touch playback | ros2 service call /audio_server qrb_ros_audio_service_msgs/srv/AudioRequest "{<br>command: "play",<br>source: "clip",<br>volume: 100,<br>}" | python3 audio_service_test.py --mode='one-touch' --source='security' --volume=100 |
-    |One-touch playback and repeat|ros2 service call /audio_server qrb_ros_audio_service_msgs/srv/AudioRequest "{<br>command: "play",<br>source: "clip",<br>volume: 100,<br>repeat: -1,<br>}"<br><br>ros2 service call /audio_server qrb_ros_audio_service_msgs/srv/AudioRequest "{<br>command: "stop",<br>stream_handle: 3520332881,<br>}"|python3 audio_service_test.py --mode='one-touch' --source='security' --volume=100 --repeat=-1|
-    |Step-by-step playback|ros2 service call /audio_server qrb_ros_audio_service_msgs/srv/AudioRequest "{<br>type: "playback",<br>command: "create",<br>source: "/tmp/music.wav",<br>volume: 100,<br>}"<br><br>ros2 service call /audio_server qrb_ros_audio_service_msgs/srv/AudioRequest "{<br>command: "start",<br>stream_handle: 2551300426,<br>}"<br><br>ros2 service call /audio_server qrb_ros_audio_service_msgs/srv/AudioRequest "{<br>command: "mute",<br>mute: true,<br>stream_handle: 2551300426,<br>}"<br><br>ros2 service call /audio_server qrb_ros_audio_service_msgs/srv/AudioRequest "{<br>command: "mute",<br>mute: false,<br>stream_handle: 2551300426,<br>}"<br><br>ros2 service call /audio_server qrb_ros_audio_service_msgs/srv/AudioRequest "{<br>command: "stop",<br>stream_handle: 2551300426,<br>}"<br><br>ros2 service call /audio_server qrb_ros_audio_service_msgs/srv/AudioRequest "{<br>command: "release",<br>stream_handle: 2551300426,<br>}"|python3 audio_service_test.py --type='playback' --source='/tmp/yesterday_48KHz.wav' --volume=100<br><br>python3 audio_service_test.py --set-mute --mute=True --stream_handle=2124364840<br><br>python3 audio_service_test.py --set-mute --mute=False --stream_handle=2124364840|
-    |Step-by-step record|ros2 service call /audio_server qrb_ros_audio_service_msgs/srv/AudioRequest "{<br>audio_info: {<br>channels: 1,<br>sample_rate: 16000,<br>sample_format: 16,<br>},<br>type: "record",<br>command: "create",<br>source: "/tmp/rec.wav",<br>}"<br><br>ros2 service call /audio_server qrb_ros_audio_service_msgs/srv/AudioRequest "{<br>command: "start",<br>stream_handle: 1502099078,<br>}"<br><br>ros2 service call /audio_server qrb_ros_audio_service_msgs/srv/AudioRequest "{<br>command: "stop",<br>stream_handle: 1502099078,<br>}"<br><br>ros2 service call /audio_server qrb_ros_audio_service_msgs/srv/AudioRequest "{<br>command: "release",<br>stream_handle: 1502099078,<br>}"|python3 audio_service_test.py --type='record' --source='/tmp/rec.wav' --channels=1 --sample_rate=16000 --sample_format=16|
-    |Publish recording data|publish recording data to /qrb_audiodata:<br>ros2 service call /audio_server qrb_ros_audio_service_msgs/srv/AudioRequest "{<br>audio_info: {<br>channels: 1,<br>sample_rate: 16000,<br>sample_format: 16,<br>},<br>type: "record",<br>command: "create",<br>pub_pcm: true,<br>}"<br><br>publish recording data to /qrb_audiodata. meanwhile, save it to file:<br>ros2 service call /audio_server qrb_ros_audio_service_msgs/srv/AudioRequest "{<br>audio_info: {<br>channels: 1,<br>sample_rate: 16000,<br>sample_format: 16,<br>},<br>type: "record",<br>command: "create",<br>pub_pcm: true,<br>source: "/tmp/rec.wav",<br>}"<br><br>ros2 service call /audio_server qrb_ros_audio_service_msgs/srv/AudioRequest "{command: "start",<br>stream_handle: 806639317,<br>}"<br>ros2 topic echo /qrb_audiodata<br><br>ros2 service call /audio_server qrb_ros_audio_service_msgs/srv/AudioRequest "{<br>command: "stop",<br>stream_handle: 806639317,<br>}"<br><br><br>ros2 service call /audio_server qrb_ros_audio_service_msgs/srv/AudioRequest "{<br>command: "release",<br>stream_handle: 806639317,<br>}"|python3 audio_service_test.py --type='record' --source='/tmp/rec.wav' --channels=1 --sample_rate=16000 --sample_format=16 --pub_pcm=True<br><br>ros2 topic echo /qrb_audiodata|
+See also the list of [contributors](https://github.com/QUIC-QRB-ROS/qrb_ros_audio_service/contributors) who participated in this project.
 
 ## License
 
-qrb_ros_audio_service is licensed under the BSD-3-clause "New" or "Revised" License. 
-
-Check out the [LICENSE](LICENSE) for more details.
+Project is licensed under the [BSD-3-clause License](https://spdx.org/licenses/BSD-3-Clause.html). See [LICENSE](./LICENSE) for the full license text.

--- a/qrb_audio_manager/include/qrb_audio_manager/audio_manager.hpp
+++ b/qrb_audio_manager/include/qrb_audio_manager/audio_manager.hpp
@@ -21,16 +21,21 @@ class IAudioManager
 {
 public:
   virtual uint32_t create_playback_stream(std::string source,
+      uint32_t sample_rate,
+      uint8_t channels,
+      uint8_t sample_format,
       std::string coding_format,
       uint8_t volume,
       std::string play_mode,
-      int8_t repeat) = 0;
+      int8_t repeat,
+      std::string subs_name) = 0;
   virtual uint32_t create_record_stream(uint32_t sample_rate,
       uint8_t channels,
       uint8_t sample_format,
       std::string coding_format,
       std::string source,
-      bool pub_pcm) = 0;
+      bool pub_pcm,
+      std::string pub_name) = 0;
   virtual bool start_stream(uint32_t stream_handle) = 0;
   virtual bool stop_stream(uint32_t stream_handle) = 0;
   virtual bool release_stream(uint32_t stream_handle) = 0;
@@ -63,25 +68,23 @@ extern std::map<std::string, AudioManagerPlayMode> audio_manager_play_mode;
 class AudioManager : public IAudioManager
 {
 public:
-  AudioManager() : worker_([this] { this->worker_thread(std::ref(queue_)); }) {}
-  ~AudioManager()
-  {
-    queue_.stop();
-    if (worker_.joinable())
-      worker_.join();
-  }
-  static AudioManager * getInstance();
+  static AudioManager * get_instance();
   uint32_t create_playback_stream(std::string source,
+      uint32_t sample_rate,
+      uint8_t channels,
+      uint8_t sample_format,
       std::string coding_format,
       uint8_t volume,
       std::string play_mode,
-      int8_t repeat) override;
+      int8_t repeat,
+      std::string subs_name) override;
   uint32_t create_record_stream(uint32_t sample_rate,
       uint8_t channels,
       uint8_t sample_format,
       std::string coding_format,
       std::string source,
-      bool pub_pcm) override;
+      bool pub_pcm,
+      std::string pub_name) override;
   bool start_stream(uint32_t stream_handle) override;
   bool stop_stream(uint32_t stream_handle) override;
   bool release_stream(uint32_t stream_handle) override;
@@ -95,6 +98,13 @@ public:
   void clean() { streams_.clear(); };
 
 private:
+  AudioManager() : worker_([this] { this->worker_thread(std::ref(queue_)); }) {}
+  ~AudioManager()
+  {
+    queue_.stop();
+    if (worker_.joinable())
+      worker_.join();
+  }
   static AudioManager * instance_;
   std::unordered_map<uint32_t, std::shared_ptr<Stream>> streams_{};
   std::map<std::string, std::string> buildin_sounds_{};

--- a/qrb_audio_manager/include/qrb_audio_manager/stream.hpp
+++ b/qrb_audio_manager/include/qrb_audio_manager/stream.hpp
@@ -66,6 +66,8 @@ struct StreamConfigs
   uint8_t volume{ 50 };
   bool mute{ false };
   bool pub_pcm{ false };
+  std::string pub_name;
+  std::string subs_name;
 };
 
 struct DomainConfigs
@@ -96,6 +98,12 @@ public:
       bool use_async);
 
 protected:
+  Stream(){};
+  Stream(uint32_t stream_handle,
+      uint32_t sample_rate,
+      uint8_t channels,
+      uint8_t sample_format,
+      std::string coding_format);
   StreamConfigs stream_configs_;
   std::function<bool(const void * const, StreamCommand, uint32_t &)> get_domain_cb(
       uint8_t domain_id);
@@ -114,7 +122,8 @@ public:
       uint8_t sample_format,
       std::string coding_format,
       std::string source,
-      bool pub_pcm);
+      bool pub_pcm,
+      std::string pub_name);
 };
 
 class PlaybackStream : public Stream
@@ -122,10 +131,14 @@ class PlaybackStream : public Stream
 public:
   PlaybackStream(uint32_t stream_handle,
       std::string source,
+      uint32_t sample_rate,
+      uint8_t channels,
+      uint8_t sample_format,
       std::string coding_format,
       uint8_t volume,
       std::string play_mode,
-      int8_t repeat);
+      int8_t repeat,
+      std::string subs_name);
   bool set_mute(bool mute);
 };
 

--- a/qrb_audio_manager/src/audio_manager.cpp
+++ b/qrb_audio_manager/src/audio_manager.cpp
@@ -3,6 +3,7 @@
 
 #define LOG_TAG "AudioManager"
 
+// clang-format off
 #include <string>
 #include <random>
 #include <sstream>
@@ -11,6 +12,7 @@
 
 #include "qrb_audio_manager/stream.hpp"
 #include "qrb_audio_manager/audio_manager.hpp"
+// clang-format on
 
 #define BUILDIN_SOUNDS_PATH "/opt/qcom/qirp-sdk/usr/share/qrb-audio-manager/sounds"
 
@@ -21,6 +23,7 @@ namespace qrb
 namespace audio_manager
 {
 
+// clang-format off
 std::map<std::string, AudioManagerCommand> audio_manager_cmd_name {
   { "play", AudioManagerCommand::PLAY },
   { "create", AudioManagerCommand::CREATE },
@@ -35,10 +38,11 @@ std::map<std::string, AudioManagerPlayMode> audio_manager_play_mode {
   { "normal", AudioManagerPlayMode::NORMAL },
   { "one-touch", AudioManagerPlayMode::ONE_TOUCH }
 };
+// clang-format on
 
 AudioManager * AudioManager::instance_ = nullptr;
 
-AudioManager * AudioManager::getInstance()
+AudioManager * AudioManager::get_instance()
 {
   if (instance_ == nullptr) {
     instance_ = new AudioManager();
@@ -49,10 +53,14 @@ AudioManager * AudioManager::getInstance()
 }
 
 uint32_t AudioManager::create_playback_stream(std::string source,
+    uint32_t sample_rate,
+    uint8_t channels,
+    uint8_t sample_format,
     std::string coding_format,
     uint8_t volume,
     std::string play_mode,
-    int8_t repeat)
+    int8_t repeat,
+    std::string subs_name)
 {
   auto stream_handle = generate_key();
   while (streams_.find(stream_handle) != streams_.end()) {
@@ -63,8 +71,8 @@ uint32_t AudioManager::create_playback_stream(std::string source,
   if (it != buildin_sounds_.end())
     source = it->second;
 
-  std::shared_ptr<Stream> stream_ptr = std::make_shared<PlaybackStream>(
-      stream_handle, source, coding_format, volume, play_mode, repeat);
+  std::shared_ptr<Stream> stream_ptr = std::make_shared<PlaybackStream>(stream_handle, source,
+      sample_rate, channels, sample_format, coding_format, volume, play_mode, repeat, subs_name);
 
   if (!stream_ptr->open()) {
     stream_ptr = nullptr;
@@ -93,15 +101,16 @@ uint32_t AudioManager::create_record_stream(uint32_t sample_rate,
     uint8_t sample_format,
     std::string coding_format,
     std::string source,
-    bool pub_pcm)
+    bool pub_pcm,
+    std::string pub_name)
 {
   auto stream_handle = generate_key();
   while (streams_.find(stream_handle) != streams_.end()) {
     stream_handle = generate_key();
   }
 
-  std::shared_ptr<Stream> stream_ptr = std::make_shared<RecordStream>(
-      stream_handle, sample_rate, channels, sample_format, coding_format, source, pub_pcm);
+  std::shared_ptr<Stream> stream_ptr = std::make_shared<RecordStream>(stream_handle, sample_rate,
+      channels, sample_format, coding_format, source, pub_pcm, pub_name);
 
   if (!stream_ptr->open()) {
     stream_ptr = nullptr;

--- a/qrb_audio_manager/src/playback_stream.cpp
+++ b/qrb_audio_manager/src/playback_stream.cpp
@@ -14,24 +14,30 @@ namespace audio_manager
 
 PlaybackStream::PlaybackStream(uint32_t stream_handle,
     std::string source,
+    uint32_t sample_rate,
+    uint8_t channels,
+    uint8_t sample_format,
     std::string coding_format,
     uint8_t volume,
     std::string play_mode,
-    int8_t repeat)
+    int8_t repeat,
+    std::string subs_name)
+  : Stream(stream_handle, sample_rate, channels, sample_format, coding_format)
 {
-  AM_LOGD(LOG_TAG, "stream handle 0x" << (std::ostringstream() << std::hex << stream_handle).str()
-                                      << ", source " << source << ", coding_format "
-                                      << coding_format << ", volume " << static_cast<int>(volume)
-                                      << ", play_mode " << play_mode << ", repeat "
-                                      << static_cast<int>(repeat));
+  AM_LOGD(LOG_TAG, "stream handle 0x"
+                       << (std::ostringstream() << std::hex << stream_handle).str() << ", source "
+                       << source << ", sample_rate " << sample_rate << ", channels "
+                       << static_cast<int>(channels) << ", sample_format "
+                       << static_cast<int>(sample_format) << ", coding_format " << coding_format
+                       << ", volume " << static_cast<int>(volume) << ", play_mode " << play_mode
+                       << ", repeat " << static_cast<int>(repeat) << ", source " << source);
 
-  stream_configs_.stream_handle = stream_handle;
   stream_configs_.type = StreamType::PLAYBACK;
   stream_configs_.source = source;
-  stream_configs_.coding_format = coding_format;
   stream_configs_.volume = (volume == 0) ? 80 : volume;
   stream_configs_.play_mode = play_mode;
   stream_configs_.repeat = repeat;
+  stream_configs_.subs_name = subs_name;
 
   stream_configs_.state = StreamState::INIT;
 }

--- a/qrb_audio_manager/src/record_stream.cpp
+++ b/qrb_audio_manager/src/record_stream.cpp
@@ -18,23 +18,21 @@ RecordStream::RecordStream(uint32_t stream_handle,
     uint8_t sample_format,
     std::string coding_format,
     std::string source,
-    bool pub_pcm)
+    bool pub_pcm,
+    std::string pub_name)
+  : Stream(stream_handle, sample_rate, channels, sample_format, coding_format)
 {
   AM_LOGD(LOG_TAG, "stream handle 0x" << (std::ostringstream() << std::hex << stream_handle).str()
                                       << ", source " << source << ", sample_rate " << sample_rate
                                       << ", channels " << static_cast<int>(channels)
                                       << ", sample_format " << static_cast<int>(sample_format)
                                       << ", coding_format " << coding_format << ", pub_pcm "
-                                      << pub_pcm);
+                                      << pub_pcm << ", pub_name " << pub_name);
 
-  stream_configs_.stream_handle = stream_handle;
   stream_configs_.type = StreamType::RECORD;
-  stream_configs_.sample_rate = sample_rate;
-  stream_configs_.channels = channels;
-  stream_configs_.sample_format = sample_format;
-  stream_configs_.coding_format = coding_format;
   stream_configs_.source = source;
   stream_configs_.pub_pcm = pub_pcm;
+  stream_configs_.pub_name = pub_name;
 
   stream_configs_.state = StreamState::INIT;
 }

--- a/qrb_audio_manager/src/stream.cpp
+++ b/qrb_audio_manager/src/stream.cpp
@@ -3,15 +3,18 @@
 
 #define LOG_TAG "Stream"
 
+// clang-format off
 #include <sstream>
 
 #include "qrb_audio_manager/stream.hpp"
+// clang-format on
 
 namespace qrb
 {
 namespace audio_manager
 {
 
+// clang-format off
 std::map<StreamType, std::string> audio_stream_type_name {
   { StreamType::RECORD, "record" },
   { StreamType::PLAYBACK, "playback" }
@@ -24,8 +27,22 @@ std::map<StreamCommand, std::string> audio_stream_cmd_name {
   { StreamCommand::CLOSE, "close" },
   { StreamCommand::MUTE, "mute" }
 };
+// clang-format on
 
 DomainConfigs Stream::domain_configs_[DOMAIN_ID_MAX];
+
+Stream::Stream(uint32_t stream_handle,
+    uint32_t sample_rate,
+    uint8_t channels,
+    uint8_t sample_format,
+    std::string coding_format)
+{
+  stream_configs_.stream_handle = stream_handle;
+  stream_configs_.sample_rate = sample_rate;
+  stream_configs_.channels = channels;
+  stream_configs_.sample_format = sample_format;
+  stream_configs_.coding_format = coding_format;
+}
 
 bool Stream::open()
 {

--- a/qrb_ros_audio_service/include/qrb_ros_audio_service/audio_common_client.hpp
+++ b/qrb_ros_audio_service/include/qrb_ros_audio_service/audio_common_client.hpp
@@ -1,9 +1,10 @@
 // Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#ifndef QRB_ROS_DEMOS_ACTION__ACTION_CLIENT_HPP_
-#define QRB_ROS_DEMOS_ACTION__ACTION_CLIENT_HPP_
+#ifndef QRB_ROS_AUDIO_SERVICE__AUDIO_COMMON_CLIENT_HPP_
+#define QRB_ROS_AUDIO_SERVICE__AUDIO_COMMON_CLIENT_HPP_
 
+// clang-format off
 #include <memory>
 
 #include <rclcpp/rclcpp.hpp>
@@ -11,6 +12,7 @@
 
 #include "qrb_audio_manager/audio_manager.hpp"
 #include "qrb_ros_audio_common_msgs/action/audio_common.hpp"
+// clang-format on
 
 using AudioCommonAction = qrb_ros_audio_common_msgs::action::AudioCommon;
 using GoalHandleAudioCommonAction = rclcpp_action::ClientGoalHandle<AudioCommonAction>;
@@ -52,4 +54,4 @@ private:
 }  // namespace audio_service
 }  // namespace qrb_ros
 
-#endif  // QRB_ROS_DEMOS_ACTION__ACTION_CLIENT_HPP_
+#endif  // QRB_ROS_AUDIO_SERVICE__AUDIO_COMMON_CLIENT_HPP_

--- a/qrb_ros_audio_service/include/qrb_ros_audio_service/audio_service.hpp
+++ b/qrb_ros_audio_service/include/qrb_ros_audio_service/audio_service.hpp
@@ -4,10 +4,12 @@
 #ifndef QRB_ROS_AUDIO_SERVICE__AUDIO_SERVER_HPP_
 #define QRB_ROS_AUDIO_SERVICE__AUDIO_SERVER_HPP_
 
+// clang-format off
 #include <rclcpp/rclcpp.hpp>
 #include <rmw/types.h>
 
 #include "qrb_ros_audio_service_msgs/srv/audio_request.hpp"
+// clang-format on
 
 using AudioService = qrb_ros_audio_service_msgs::srv::AudioRequest;
 

--- a/qrb_ros_audio_service/src/audio_common_client.cpp
+++ b/qrb_ros_audio_service/src/audio_common_client.cpp
@@ -1,9 +1,11 @@
 // Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
+// clang-format off
 #include <cinttypes>
 
 #include "qrb_ros_audio_service/audio_common_client.hpp"
+// clang-format on
 
 using namespace std::placeholders;
 
@@ -170,16 +172,19 @@ bool AudioCommonClient::stream_cb(const void * const payload,
   switch (cmd) {
     case qrb::audio_manager::StreamCommand::OPEN:
       if (configs->type == StreamType::PLAYBACK) {
-        goal_msg->audio_info.coding_format = configs->coding_format;
         goal_msg->repeat = configs->repeat;
         goal_msg->volume = configs->volume;
+        goal_msg->topic_name = configs->subs_name;
       } else {
-        goal_msg->audio_info.sample_rate = configs->sample_rate;
-        goal_msg->audio_info.channels = configs->channels;
-        goal_msg->audio_info.sample_format = configs->sample_format;
-        goal_msg->audio_info.coding_format = configs->coding_format;
         goal_msg->pub_pcm = configs->pub_pcm;
+        goal_msg->topic_name = configs->pub_name;
       }
+
+      goal_msg->audio_info.sample_rate = configs->sample_rate;
+      goal_msg->audio_info.channels = configs->channels;
+      goal_msg->audio_info.sample_format = configs->sample_format;
+      goal_msg->audio_info.coding_format = configs->coding_format;
+
       goal_msg->audio_service_stream_handle = configs->stream_handle;
       break;
     case qrb::audio_manager::StreamCommand::START:

--- a/tests/audio_service_test.py
+++ b/tests/audio_service_test.py
@@ -53,7 +53,7 @@ class AudioServiceClient(Node):
             req.command = "stop"
             self.send_request(req)
 
-        if self.stream_handle and (self.mode == 'step-by-step'):
+        if self.stream_handle and (self.mode == "step-by-step"):
             time.sleep(0.5)
 
             print("release stream")
@@ -82,13 +82,14 @@ def main():
     parser.add_argument("--set-mute", action="store_true")
     parser.add_argument("--type", type=str, default="")
     parser.add_argument("--mode", type=str, default="step-by-step")
-    parser.add_argument("--source", type=str, default="security")
+    parser.add_argument("--source", type=str, default="")
     parser.add_argument("--volume", type=int, default=100)
     parser.add_argument("--repeat", type=int, default=0)
     parser.add_argument("--channels", type=int, default=1)
     parser.add_argument("--sample_rate", type=int, default=16000)
     parser.add_argument("--sample_format", type=int, default=16)
     parser.add_argument("--pub_pcm", type=str2bool, default=False)
+    parser.add_argument("--topic_name", type=str, default="")
     parser.add_argument("--stream_handle", type=int, default=0)
     parser.add_argument("--mute", type=str2bool, default=False)
     args = parser.parse_args()
@@ -101,6 +102,16 @@ def main():
     exit = False
 
     req = AudioRequest.Request()
+    req.audio_info = AudioInfo(
+        channels=args.channels,
+        sample_rate=args.sample_rate,
+        sample_format=args.sample_format,
+    )
+    if len(args.source) != 0:
+        req.source = args.source
+    if len(args.topic_name) != 0:
+        req.topic_name = args.topic_name
+
     if args.get_buildin_sound:
         req.command = "get-buildin-sound"
         audio_service_client.get_logger().info("request get-buildin-sound")
@@ -114,31 +125,35 @@ def main():
         else:
             req.command = "create"
         req.type = args.type
-        req.source = args.source
         req.volume = args.volume
         req.repeat = args.repeat
         audio_service_client.get_logger().info(
-            "request playback. mode %s source %s volume %d repeat %d"
-            % (args.mode, req.source, req.volume, req.repeat)
+            "request playback. mode %s source %s channels %d sample_rate %d sample_format %d volume %d repeat %d topic_name %s"
+            % (
+                args.mode,
+                req.source,
+                args.channels,
+                args.sample_rate,
+                args.sample_format,
+                req.volume,
+                req.repeat,
+                req.topic_name,
+            )
         )
     elif args.type == "record":
-        req.audio_info = AudioInfo(
-            channels=args.channels,
-            sample_rate=args.sample_rate,
-            sample_format=args.sample_format,
-        )
+
         req.type = args.type
         req.command = "create"
-        req.source = args.source
         req.pub_pcm = args.pub_pcm
         audio_service_client.get_logger().info(
-            "request record. source %s channels %d sample_rate %d sample_format %d pub_pcm %d"
+            "request record. source %s channels %d sample_rate %d sample_format %d pub_pcm %d topic_name %s"
             % (
                 req.source,
                 args.channels,
                 args.sample_rate,
                 args.sample_format,
                 req.pub_pcm,
+                req.topic_name,
             )
         )
     elif args.set_mute and (args.stream_handle != 0):


### PR DESCRIPTION
1.In qrb_ros_audio_service
- The sample_rate, channels, sample_format and topic_name are needed if create streaming playback.
2.In qrb-audio-manager
- Add sample_rate, channels, sample_format and subs_name for playback stream.
- Add pub_name for record stream.
3.In tests
- Update to test streaming playback.
4.Update README.md, LICENSE and build check yaml.