### PR TITLE
fix: qrb_audio_common_lib: resolve repeat not work and update version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog for package qrb_ros_audio_service
+
+## 0.0.1 (2025-04-3)
+
+- Initial version based on ROS2 Jazzy
+- Contributors👉 Ronghui Zhu
+
+## 1.0.0 (2025-8-28)
+
+- Fix repeat not work on pipewire-pulse.
+- Close file descriptors on stream close.
+- Contributors👉 Ronghui Zhu

--- a/qrb_audio_common_lib/CMakeLists.txt
+++ b/qrb_audio_common_lib/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(qrb_audio_common_lib VERSION 0.0.1)
+project(qrb_audio_common_lib VERSION 1.0.0)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -std=c++17)

--- a/qrb_audio_common_lib/include/qrb_audio_common_lib/audio_common.hpp
+++ b/qrb_audio_common_lib/include/qrb_audio_common_lib/audio_common.hpp
@@ -127,6 +127,7 @@ protected:
   static pa_context * pulse_context_;
   static pa_time_event * pulse_context_time_event_;
   static std::set<CommonAudioStream *> timestamp_streams_;
+  int file_fd = 0;
 
   CommonAudioStream(string filepath, shared_ptr<pa_sample_spec> sample_spec);
   void init_pulse_stream();

--- a/qrb_audio_common_lib/src/audio_common.cpp
+++ b/qrb_audio_common_lib/src/audio_common.cpp
@@ -350,6 +350,10 @@ CommonAudioStream::~CommonAudioStream()
     sf_close(snd_file);
     snd_file = nullptr;
   }
+
+  if (file_fd) {
+    close(file_fd);
+  }
 }
 
 uint32_t CommonAudioStream::audio_stream_open(const audio_stream_info & stream_info,

--- a/qrb_audio_common_lib/src/capture_stream.cpp
+++ b/qrb_audio_common_lib/src/capture_stream.cpp
@@ -46,7 +46,7 @@ CaptureStream::CaptureStream(string filepath, std::shared_ptr<pa_sample_spec> sa
 int CaptureStream::start_stream()
 {
   pa_buffer_attr buffer_attr;
-  pa_stream_flags_t flags;
+  pa_stream_flags_t flags = PA_STREAM_NOFLAGS;
   pa_cvolume volume;
   pa_stream * stream = get_stream_handle();
 
@@ -87,7 +87,6 @@ int CaptureStream::start_stream()
 
 int CaptureStream::sndfile_open()
 {
-  int fd;
   SF_INFO snd_file_info;
   bool match_format = false;
 
@@ -111,12 +110,12 @@ int CaptureStream::sndfile_open()
   snd_file_info.format |= SF_FORMAT_WAV;
 
   LOGI("opening %s", m_file_path.c_str());
-  if ((fd = open(m_file_path.c_str(), O_WRONLY | O_TRUNC | O_CREAT, 0666)) < 0) {
+  if ((file_fd = open(m_file_path.c_str(), O_WRONLY | O_TRUNC | O_CREAT, 0666)) < 0) {
     LOGE("open %s failed", m_file_path);
     return -ENOMEM;
   }
 
-  snd_file = sf_open_fd(fd, SFM_WRITE, &snd_file_info, 0);
+  snd_file = sf_open_fd(file_fd, SFM_WRITE, &snd_file_info, 0);
   if (snd_file == nullptr) {
     LOGE("snd file open failed");
     return -SF_ERR_MALFORMED_FILE;

--- a/qrb_audio_manager/CMakeLists.txt
+++ b/qrb_audio_manager/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(qrb_audio_manager VERSION 0.0.1)
+project(qrb_audio_manager VERSION 1.0.0)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)

--- a/qrb_ros_audio_common/package.xml
+++ b/qrb_ros_audio_common/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>qrb_ros_audio_common</name>
-  <version>0.0.1</version>
+  <version>1.0.0</version>
   <description>qrb ros audio common package</description>
   <maintainer email="quic_ronghuiz@quicinc.com">Ronghui Zhu</maintainer>
   <license>BSD-3-Clause-Clear</license>

--- a/qrb_ros_audio_service/package.xml
+++ b/qrb_ros_audio_service/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>qrb_ros_audio_service</name>
-  <version>0.0.1</version>
+  <version>1.0.0</version>
   <description>QRB ROS Audio Service</description>
   <maintainer email="quic_yuchpan@quicinc.com">yuchpan</maintainer>
   <license>BSD-3-Clause-Clear</license>


### PR DESCRIPTION
1. Fix repeat not work on pipewire-pulse.
2. Update version to 1.0.0 since passed L4.
3. Close file descriptors on stream close.